### PR TITLE
Configurable makefile compiler & add phony targets

### DIFF
--- a/source/makefile
+++ b/source/makefile
@@ -1,3 +1,6 @@
+CC=gcc
+CFLAGS=-std=c11
+
 all: debug
 
 test_gdb: debug
@@ -8,11 +11,12 @@ test: debug
 
 #gcc -fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector
 debug: *.c
-	gcc -std=c11 -O0 -g -lmcheck -ftrapv -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) -O0 -g -lmcheck -ftrapv -o zeta vm.c parser.c interp.c main.c
 
 release: *.c
-	gcc -std=c11 -O4 -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
 
 clean:
 	rm -f *.o
 
+.PHONY: test test_gdb debug release all clean


### PR DESCRIPTION
Use the $(CC) makefile variable so I can use a different compiler without
editing the makefile.

$ CC=clang make release

Also make all targets phonies.