### PR TITLE
Add gcc portability to compile on FreeBSD

### DIFF
--- a/source/interp.c
+++ b/source/interp.c
@@ -1,10 +1,14 @@
 #include <stdio.h>
+#include <sys/param.h>
 #include <string.h>
 #include <assert.h>
-#include <alloca.h>
+#ifdef BSD4_4
+    #include <stdlib.h>
+#else
+    #include <alloca.h>
+#endif
 #include "interp.h"
 #include "parser.h"
-#include "vm.h"
 
 /// Shape indices for mutable cells and closures
 /// These are initialized in init_interp(), see interp.c

--- a/source/makefile
+++ b/source/makefile
@@ -1,7 +1,21 @@
 CC=gcc
-CFLAGS=-std=c11
+CFLAGS=-std=c99
+
+OS := $(shell uname)
+ifeq ($(OS),Linux) 
+  CFLAGS+=-lmcheck
+else ifeq ($(OS),FreeBSD)
+  CC=gcc5
+endif
 
 all: debug
+
+help:
+	@echo "Zeta"
+	@echo "make         - builds VM & language"
+	@echo "make release - builds VM & language as optimized code."
+	@echo "make clean   - deletes build"
+	@echo "make help    - prints this help"
 
 test_gdb: debug
 	gdb -ex run --args ./zeta --test
@@ -11,10 +25,10 @@ test: debug
 
 #gcc -fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector
 debug: *.c
-	$(CC) $(CFLAGS) -O0 -g -lmcheck -ftrapv -o zeta vm.c parser.c interp.c main.c
+	 $(CC) $(CFLAGS) -O0 -g -ftrapv -o zeta vm.c parser.c interp.c main.c
 
 release: *.c
-	$(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
+	 $(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
 
 clean:
 	rm -f *.o

--- a/source/makefile
+++ b/source/makefile
@@ -5,7 +5,7 @@ CFLAGS_release=-O4
 
 OS := $(shell uname)
 ifeq ($(OS),Linux) 
-  CFLAGS_DEBUG+=-lmcheck
+  CFLAGS_debug+=-lmcheck
 else ifeq ($(OS),FreeBSD)
   CC=gcc5
 endif

--- a/source/makefile
+++ b/source/makefile
@@ -1,9 +1,11 @@
 CC?=gcc
 CFLAGS=-std=c11
+CFLAGS_debug=-O0 -g -ftrapv
+CFLAGS_release=-O4
 
 OS := $(shell uname)
 ifeq ($(OS),Linux) 
-  CFLAGS+=-lmcheck
+  CFLAGS_DEBUG+=-lmcheck
 else ifeq ($(OS),FreeBSD)
   CC=gcc5
 endif
@@ -34,10 +36,10 @@ test: debug
 
 #gcc -fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector
 debug: *.c
-	$(CC) $(CFLAGS) -O0 -g -ftrapv -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) $(CFLAGS_debug) -o zeta vm.c parser.c interp.c main.c
 
 release: *.c
-	$(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) $(CFLAGS_release) -o zeta vm.c parser.c interp.c main.c
 
 clean:
 	rm -f *.o

--- a/source/makefile
+++ b/source/makefile
@@ -8,11 +8,11 @@ else ifeq ($(OS),FreeBSD)
   CC=gcc5
 endif
 
-GCC_MAJ := $(shell expr `$(CC) -dumpversion | cut -d. -f1 | xargs printf '%02d'`)
-GCC_MIN := $(shell expr `$(CC) -dumpversion | cut -d. -f2 | xargs printf '%02d'`)
-GCC_4_9 := $(shell [ $(GCC_MAJ) -gt 4 -o \( $(GCC_MAJ) -eq 4 -a $(GCC_MIN) -ge 8 \) ] && echo true)
+GCC_MAJ := $(shell expr `$(CC) -dumpversion | cut -d. -f1`)
+GCC_MIN := $(shell expr `$(CC) -dumpversion | cut -d. -f2`)
+GCC_GE_4_9 := $(shell [ $(GCC_MAJ) -ge 5 -o \( $(GCC_MAJ) -eq 4 -a $(GCC_MIN) -ge 9 \) ] && echo yes)
 
-ifneq ($(GCC_4_9),true)
+ifneq ($(GCC_GE_4_9),yes)
 GCC_VER := $(shell expr `$(CC) -dumpversion`)
 $(error GCC version required is 4.9+ (your version $(GCC_VER)).)
 endif
@@ -34,10 +34,10 @@ test: debug
 
 #gcc -fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector
 debug: *.c
-	 $(CC) $(CFLAGS) -O0 -g -ftrapv -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) -O0 -g -ftrapv -o zeta vm.c parser.c interp.c main.c
 
 release: *.c
-	 $(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
+	$(CC) $(CFLAGS) -O4 -o zeta vm.c parser.c interp.c main.c
 
 clean:
 	rm -f *.o

--- a/source/makefile
+++ b/source/makefile
@@ -1,11 +1,20 @@
-CC=gcc
-CFLAGS=-std=c99
+CC?=gcc
+CFLAGS=-std=c11
 
 OS := $(shell uname)
 ifeq ($(OS),Linux) 
   CFLAGS+=-lmcheck
 else ifeq ($(OS),FreeBSD)
   CC=gcc5
+endif
+
+GCC_MAJ := $(shell expr `$(CC) -dumpversion | cut -d. -f1 | xargs printf '%02d'`)
+GCC_MIN := $(shell expr `$(CC) -dumpversion | cut -d. -f2 | xargs printf '%02d'`)
+GCC_4_9 := $(shell [ $(GCC_MAJ) -gt 4 -o \( $(GCC_MAJ) -eq 4 -a $(GCC_MIN) -ge 8 \) ] && echo true)
+
+ifneq ($(GCC_4_9),true)
+GCC_VER := $(shell expr `$(CC) -dumpversion`)
+$(error GCC version required is 4.9+ (your version $(GCC_VER)).)
 endif
 
 all: debug


### PR DESCRIPTION
Allow to build Zeta on FreeBSD:
```
# pkg install gcc5
# cd zeta/source
# gmake
```

Changed ```c11``` to ```c99``` so it works on gcc < 5:
```
root@(none):/temp/github/zeta/source# gcc -v
gcc version 4.6.3 (Ubuntu/Linaro 4.6.3-1ubuntu5) 
```
Is that an issue?