### PR TITLE
Bugs found by clang's scan-build tool

### DIFF
--- a/source/interp.c
+++ b/source/interp.c
@@ -59,7 +59,6 @@ void find_decls(heapptr_t expr, ast_fun_t* fun)
     if (shape == SHAPE_ARRAY)
     {
         array_t* array_expr = (array_t*)expr;
-        array_t* val_array = array_alloc(array_expr->len);
         for (size_t i = 0; i < array_expr->len; ++i)
             find_decls(array_get(array_expr, i).word.heapptr, fun);
 
@@ -172,7 +171,6 @@ void var_res(heapptr_t expr, ast_fun_t* fun)
     if (shape == SHAPE_ARRAY)
     {
         array_t* array_expr = (array_t*)expr;
-        array_t* val_array = array_alloc(array_expr->len);
         for (size_t i = 0; i < array_expr->len; ++i)
             var_res(array_get(array_expr, i).word.heapptr, fun);
 

--- a/source/parser.c
+++ b/source/parser.c
@@ -430,7 +430,8 @@ heapptr_t parse_string(input_t* input, char endCh)
                 case '0': ch = '\0'; break;
 
                 default:
-                return NULL;
+                    free(buf);
+                    return NULL;
             }
         }
 

--- a/source/parser.c
+++ b/source/parser.c
@@ -450,7 +450,9 @@ heapptr_t parse_string(input_t* input, char endCh)
     buf[len] = '\0';
 
     // Get the interned version of this string
-    return (heapptr_t)vm_get_cstr(buf);
+    heapptr_t heap_val = vm_get_cstr(buf);
+    free(buf);
+    return heap_val;
 }
 
 /**

--- a/source/vm.c
+++ b/source/vm.c
@@ -74,7 +74,7 @@ void value_print(value_t value)
         break;
 
         case TAG_INT64:
-        printf("%ld", value.word.int64);
+        printf("%lld", value.word.int64);
         break;
 
         case TAG_FLOAT64:


### PR DESCRIPTION
These bugs were found by clang's static analyzer. It's like magic. ~~There are still a few more it finds which I haven't fixed.~~ It looks like there is an unused value in a test. I'm going to leave that for now.